### PR TITLE
Fixed definition and removed the use of REG_SYNC_WORD.

### DIFF
--- a/ESP-sc-gway/ESP-sc-gway.h
+++ b/ESP-sc-gway/ESP-sc-gway.h
@@ -123,7 +123,7 @@
 #define REG_IRQ_FLAGS_MASK          0x11
 #define REG_MAX_PAYLOAD_LENGTH      0x23
 #define REG_HOP_PERIOD              0x24
-#define REG_SYNC_WORD               0x39
+#define REG_SYNC_WORD               0x27
 #define REG_VERSION                 0x42
 
 #define SX72_MODE_RX_CONTINUOS      0x85

--- a/ESP-sc-gway/ESP-sc-gway.ino
+++ b/ESP-sc-gway/ESP-sc-gway.ino
@@ -640,8 +640,6 @@ void SetupLoRa()
   writeRegister(REG_FRF_MID, (uint8_t)(frf >> 8) );
   writeRegister(REG_FRF_LSB, (uint8_t)(frf >> 0) );
 
-  writeRegister(REG_SYNC_WORD, 0x34); // LoRaWAN public sync word
-
   // Set spreading Factor
   if (sx1272) {
     if (sf == SF11 || sf == SF12) {


### PR DESCRIPTION
The definition of REG_SYNC_WORD was 0x39 and not 0x27, as it should have been.
Furthermore, the use of REG_SYNC_WORD in LoRa mode is reserved, so I removed the setting of this register. This should make no difference, as the position that was written to before (0x39), was also reserved, in LoRa mode.

Please note: I have no hardware to test this on (yet), but I believe that it should work. I'll appreciate it if someone could verify the correct behaviour, before accepting this pull request.